### PR TITLE
Fix for the undefined target bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ window.onload = () => {
 
     anchor.addEventListener('click', e => {
       e.preventDefault();
-      let target = e.target.href;
+      let target = anchor.href;
 
       console.log(transition_el);
 


### PR DESCRIPTION
Using `e.target.href;` seems to cause problems for certain `<a>` elements. I've found that using `anchor.href;` seems to eliminate those problems. See issue #1. Would recommend some testing because I'm half asleep as I'm writing this but it seems to work fine so far.